### PR TITLE
Upgrade to 2.2.0, and refer to new doc site

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,6 +1,6 @@
 The MIT License
 
-Copyright (c) 2016 Google, Inc. http://angular.io/dart
+Copyright (c) 2016 Google, Inc.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
-# Angular Dart 2 API Examples
+# AngularDart API Examples
 
-[AngularDart](https://angular.io/dart) examples use in the [API documentation](https://angular.io/docs/dart/latest/api/).
+[AngularDart][] examples used in the [API documentation][API].
+
+[AngularDart]: https://webdev.dartlang.org/angular
+[API]: https://webdev.dartlang.org/angular/api

--- a/common/pipes/lib/app_component.dart
+++ b/common/pipes/lib/app_component.dart
@@ -1,8 +1,5 @@
 /// @license
 /// Copyright Google Inc. All Rights Reserved.
-///
-/// Use of this source code is governed by an MIT-style license that can be
-/// found in the LICENSE file at https://angular.io/license
 
 import 'package:angular2/core.dart';
 

--- a/common/pipes/lib/app_component.html
+++ b/common/pipes/lib/app_component.html
@@ -1,3 +1,3 @@
-<h1>Angular Dart API Examples for Pipes</h1>
+<h1>AngularDart API Examples for Pipes</h1>
 <async-greeter></async-greeter>
 <async-time></async-time>

--- a/common/pipes/lib/async_pipe.dart
+++ b/common/pipes/lib/async_pipe.dart
@@ -1,9 +1,6 @@
 /**
  * @license
  * Copyright Google Inc. All Rights Reserved.
- *
- * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
  */
 
 import 'dart:async';

--- a/common/pipes/pubspec.yaml
+++ b/common/pipes/pubspec.yaml
@@ -1,10 +1,11 @@
 name: pipes
-description: Angular Dart API Examples for Pipes
+description: AngularDart API Examples for Pipes
 version: 0.0.1
 environment:
   sdk: '>=1.19.0 <2.0.0'
 dependencies:
-  angular2: 2.0.0-beta.22
+  angular2: ^2.2.0
+dev_dependencies:
   browser: ^0.10.0
   dart_to_js_script_rewriter: ^1.0.1
 transformers:

--- a/common/pipes/web/index.html
+++ b/common/pipes/web/index.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <title>Angular Dart API Examples for Pipes</title>
+    <title>AngularDart API Examples for Pipes</title>
 
     <script defer src="main.dart" type="application/dart"></script>
     <script defer src="packages/browser/dart.js"></script>

--- a/common/pipes/web/main.dart
+++ b/common/pipes/web/main.dart
@@ -1,8 +1,5 @@
 /// @license
 /// Copyright Google Inc. All Rights Reserved.
-///
-/// Use of this source code is governed by an MIT-style license that can be
-/// found in the LICENSE file at https://angular.io/license
 
 import 'package:angular2/platform/browser.dart';
 


### PR DESCRIPTION
- upgrade to angular2 2.2.0
- “Angular Dart” -> AngularDart
- Replace/remove references to angular.io